### PR TITLE
Timestamp checking & misc improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-ocsp": "^2.6.0",
+        "@peculiar/asn1-tsp": "^2.6.0",
         "@peculiar/x509": "^1.12.3",
         "@xmldom/xmldom": "^0.9.8",
         "fflate": "^0.8.2",
@@ -1558,15 +1559,15 @@
       }
     },
     "node_modules/@peculiar/asn1-cms": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.3.15.tgz",
-      "integrity": "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
+      "integrity": "sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.15",
-        "@peculiar/asn1-x509": "^2.3.15",
-        "@peculiar/asn1-x509-attr": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-x509-attr": "^2.6.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
@@ -1671,6 +1672,19 @@
         "tslib": "^2.8.1"
       }
     },
+    "node_modules/@peculiar/asn1-tsp": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-tsp/-/asn1-tsp-2.6.0.tgz",
+      "integrity": "sha512-ioTIU9IUMNoQACXTOnqRGth8jsqFybI8KYRklEK3oCZh5+9o/Kd1f/oKKGDhQvNLlJct6gKVtR8Et9uHH342aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/@peculiar/asn1-x509": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
@@ -1684,14 +1698,14 @@
       }
     },
     "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.3.15.tgz",
-      "integrity": "sha512-TWJVJhqc+IS4MTEML3l6W1b0sMowVqdsnI4dnojg96LvTuP8dga9f76fjP07MUuss60uSyT2ckoti/2qHXA10A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.0.tgz",
+      "integrity": "sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.15",
-        "@peculiar/asn1-x509": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "description": "A JavaScript library for listing, parsing, and verifying the contents and signatures of electronic documents (eDoc) and Associated Signature Containers (ASiC-E), supporting EU eIDAS standards for digital signatures and electronic seals.",
   "dependencies": {
     "@peculiar/asn1-ocsp": "^2.6.0",
+    "@peculiar/asn1-tsp": "^2.6.0",
     "@peculiar/x509": "^1.12.3",
     "@xmldom/xmldom": "^0.9.8",
     "fflate": "^0.8.2",

--- a/src/core/parser/signatureParser.ts
+++ b/src/core/parser/signatureParser.ts
@@ -283,6 +283,16 @@ export function parseSignatureElement(signatureElement: Element, xmlDoc: Documen
     }
   }
 
+  // Extract signature timestamp (RFC 3161) from xades:SignatureTimeStamp
+  let signatureTimestamp: string | undefined;
+  const timestampElement = querySelector(
+    xmlDoc,
+    "xades\\:EncapsulatedTimeStamp, EncapsulatedTimeStamp",
+  );
+  if (timestampElement && timestampElement.textContent) {
+    signatureTimestamp = timestampElement.textContent.replace(/\s+/g, "");
+  }
+
   return {
     id: signatureId,
     signingTime,
@@ -298,6 +308,7 @@ export function parseSignatureElement(signatureElement: Element, xmlDoc: Documen
     signatureValue,
     signedInfoXml,
     canonicalizationMethod,
+    signatureTimestamp,
   };
 }
 

--- a/src/core/parser/types.ts
+++ b/src/core/parser/types.ts
@@ -41,4 +41,6 @@ export interface SignatureInfo {
   signedInfoXml?: string; // The XML string of the SignedInfo element
   rawXml?: string; // The full raw XML of the signature
   canonicalizationMethod?: string; // The canonicalization method used
+  /** RFC 3161 timestamp token (base64 encoded) from xades:EncapsulatedTimeStamp */
+  signatureTimestamp?: string;
 }

--- a/src/core/revocation/ocsp.ts
+++ b/src/core/revocation/ocsp.ts
@@ -15,7 +15,7 @@ import { AlgorithmIdentifier } from "@peculiar/asn1-x509";
 import { OctetString } from "@peculiar/asn1-schema";
 import { RevocationResult } from "./types";
 import { fetchOCSP, fetchIssuerCertificate } from "./fetch";
-import { arrayBufferToBase64 } from "../../utils/encoding";
+import { arrayBufferToBase64, arrayBufferToPEM, hexToArrayBuffer } from "../../utils/encoding";
 
 /**
  * OID for Authority Information Access extension
@@ -140,15 +140,6 @@ export async function fetchIssuerFromAIA(
 }
 
 /**
- * Convert ArrayBuffer to PEM format
- */
-function arrayBufferToPEM(buffer: ArrayBuffer): string {
-  const base64 = arrayBufferToBase64(buffer);
-  const lines = base64.match(/.{1,64}/g) || [];
-  return `-----BEGIN CERTIFICATE-----\n${lines.join("\n")}\n-----END CERTIFICATE-----`;
-}
-
-/**
  * Build OCSP request for a certificate
  * @param cert Certificate to check
  * @param issuerCert Issuer certificate
@@ -188,17 +179,6 @@ export async function buildOCSPRequest(
   const ocspRequest = new OCSPRequest({ tbsRequest });
 
   return AsnConvert.serialize(ocspRequest);
-}
-
-/**
- * Convert hex string to ArrayBuffer
- */
-function hexToArrayBuffer(hex: string): ArrayBuffer {
-  const bytes = new Uint8Array(hex.length / 2);
-  for (let i = 0; i < hex.length; i += 2) {
-    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
-  }
-  return bytes.buffer;
 }
 
 /**

--- a/src/core/timestamp/index.ts
+++ b/src/core/timestamp/index.ts
@@ -1,0 +1,10 @@
+// src/core/timestamp/index.ts
+
+export { TimestampInfo, TimestampVerificationResult, TimestampVerificationOptions } from "./types";
+
+export {
+  parseTimestamp,
+  verifyTimestamp,
+  verifyTimestampCoversSignature,
+  getTimestampTime,
+} from "./verify";

--- a/src/core/timestamp/types.ts
+++ b/src/core/timestamp/types.ts
@@ -1,0 +1,49 @@
+// src/core/timestamp/types.ts
+
+/**
+ * Parsed timestamp information from RFC 3161 TimeStampToken
+ */
+export interface TimestampInfo {
+  /** The timestamp generation time (when TSA signed) */
+  genTime: Date;
+  /** TSA policy OID */
+  policy: string;
+  /** Serial number of the timestamp */
+  serialNumber: string;
+  /** Hash algorithm used for the message imprint */
+  hashAlgorithm: string;
+  /** The message imprint (hash of timestamped data) */
+  messageImprint: string;
+  /** TSA name (if provided) */
+  tsaName?: string;
+  /** TSA certificate (PEM format) */
+  tsaCertificate?: string;
+  /** Accuracy of the timestamp (in seconds) */
+  accuracy?: number;
+}
+
+/**
+ * Result of timestamp verification
+ */
+export interface TimestampVerificationResult {
+  /** Whether the timestamp is valid */
+  isValid: boolean;
+  /** Parsed timestamp info (if parsing succeeded) */
+  info?: TimestampInfo;
+  /** Error or status message */
+  reason?: string;
+  /** Whether the timestamp covers the signature value correctly */
+  coversSignature?: boolean;
+}
+
+/**
+ * Options for timestamp verification
+ */
+export interface TimestampVerificationOptions {
+  /** The signature value that the timestamp should cover (base64) */
+  signatureValue?: string;
+  /** Verify the TSA certificate chain */
+  verifyTsaCertificate?: boolean;
+  /** Check TSA certificate revocation */
+  checkTsaRevocation?: boolean;
+}

--- a/src/core/timestamp/types.ts
+++ b/src/core/timestamp/types.ts
@@ -1,5 +1,7 @@
 // src/core/timestamp/types.ts
 
+import { RevocationResult } from "../revocation/types";
+
 /**
  * Parsed timestamp information from RFC 3161 TimeStampToken
  */
@@ -34,6 +36,8 @@ export interface TimestampVerificationResult {
   reason?: string;
   /** Whether the timestamp covers the signature value correctly */
   coversSignature?: boolean;
+  /** TSA certificate revocation check result (if checkTsaRevocation was enabled) */
+  tsaRevocation?: RevocationResult;
 }
 
 /**

--- a/src/core/timestamp/verify.ts
+++ b/src/core/timestamp/verify.ts
@@ -154,6 +154,7 @@ async function computeHash(data: ArrayBuffer, algorithm: string): Promise<ArrayB
   }
 
   // Node.js fallback
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const nodeCrypto = require("crypto");
   const hash = nodeCrypto.createHash(algorithm.toLowerCase().replace("-", ""));
   hash.update(Buffer.from(data));

--- a/src/core/timestamp/verify.ts
+++ b/src/core/timestamp/verify.ts
@@ -1,0 +1,321 @@
+// src/core/timestamp/verify.ts
+
+import { X509Certificate } from "@peculiar/x509";
+import { AsnConvert } from "@peculiar/asn1-schema";
+import { ContentInfo, SignedData } from "@peculiar/asn1-cms";
+import { TSTInfo } from "@peculiar/asn1-tsp";
+import { TimestampInfo, TimestampVerificationResult, TimestampVerificationOptions } from "./types";
+
+/**
+ * OID for SignedData content type
+ */
+const id_signedData = "1.2.840.113549.1.7.2";
+
+/**
+ * OID for TSTInfo content type
+ */
+const id_ct_TSTInfo = "1.2.840.113549.1.9.16.1.4";
+
+/**
+ * Convert ArrayBuffer to hex string
+ */
+function bufferToHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Convert ArrayBuffer to base64 string
+ */
+function bufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Decode base64 to ArrayBuffer
+ */
+function base64ToBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+/**
+ * Get hash algorithm name from OID
+ */
+function getHashAlgorithmName(oid: string): string {
+  const hashAlgorithms: Record<string, string> = {
+    "1.3.14.3.2.26": "SHA-1",
+    "2.16.840.1.101.3.4.2.1": "SHA-256",
+    "2.16.840.1.101.3.4.2.2": "SHA-384",
+    "2.16.840.1.101.3.4.2.3": "SHA-512",
+  };
+  return hashAlgorithms[oid] || oid;
+}
+
+/**
+ * Format certificate as PEM
+ */
+function formatPEM(derBytes: ArrayBuffer): string {
+  const base64 = bufferToBase64(derBytes);
+  const lines = base64.match(/.{1,64}/g) || [];
+  return `-----BEGIN CERTIFICATE-----\n${lines.join("\n")}\n-----END CERTIFICATE-----`;
+}
+
+/**
+ * Parse RFC 3161 TimeStampToken from base64
+ * @param timestampBase64 Base64-encoded timestamp token
+ * @returns Parsed timestamp info or null if parsing fails
+ */
+export function parseTimestamp(timestampBase64: string): TimestampInfo | null {
+  try {
+    const tokenBuffer = base64ToBuffer(timestampBase64);
+
+    // Parse as ContentInfo (TimeStampToken extends ContentInfo)
+    const contentInfo = AsnConvert.parse(tokenBuffer, ContentInfo);
+
+    // Verify it's SignedData
+    if (contentInfo.contentType !== id_signedData) {
+      console.warn("Timestamp is not SignedData");
+      return null;
+    }
+
+    // Parse SignedData
+    const signedData = AsnConvert.parse(contentInfo.content, SignedData);
+
+    // Verify encapsulated content is TSTInfo
+    if (signedData.encapContentInfo.eContentType !== id_ct_TSTInfo) {
+      console.warn("SignedData does not contain TSTInfo");
+      return null;
+    }
+
+    // Parse TSTInfo
+    if (!signedData.encapContentInfo.eContent) {
+      console.warn("No eContent in SignedData");
+      return null;
+    }
+
+    // Extract buffer from EncapsulatedContent - it may be in .single (OctetString) or .any (ArrayBuffer)
+    const eContent = signedData.encapContentInfo.eContent;
+    let tstInfoBuffer: ArrayBuffer;
+    if (eContent.single) {
+      // OctetString has a buffer property
+      tstInfoBuffer = eContent.single.buffer;
+    } else if (eContent.any) {
+      tstInfoBuffer = eContent.any;
+    } else {
+      // Try to serialize the whole thing if it's already ASN.1 parsed
+      tstInfoBuffer = AsnConvert.serialize(eContent);
+    }
+
+    const tstInfo = AsnConvert.parse(tstInfoBuffer, TSTInfo);
+
+    // Extract TSA certificate if present
+    let tsaCertificate: string | undefined;
+    if (signedData.certificates && signedData.certificates.length > 0) {
+      // Get the first certificate (usually the TSA cert)
+      const cert = signedData.certificates[0];
+      if ("certificate" in cert && cert.certificate) {
+        tsaCertificate = formatPEM(AsnConvert.serialize(cert.certificate));
+      }
+    }
+
+    // Extract TSA name if present
+    let tsaName: string | undefined;
+    if (tstInfo.tsa) {
+      if (tstInfo.tsa.directoryName) {
+        tsaName = tstInfo.tsa.directoryName.toString();
+      } else if (tstInfo.tsa.uniformResourceIdentifier) {
+        tsaName = tstInfo.tsa.uniformResourceIdentifier;
+      }
+    }
+
+    // Calculate accuracy in seconds (if provided)
+    let accuracy: number | undefined;
+    if (tstInfo.accuracy) {
+      accuracy =
+        (tstInfo.accuracy.seconds || 0) +
+        (tstInfo.accuracy.millis || 0) / 1000 +
+        (tstInfo.accuracy.micros || 0) / 1000000;
+    }
+
+    return {
+      genTime: tstInfo.genTime,
+      policy: tstInfo.policy,
+      serialNumber: bufferToHex(tstInfo.serialNumber),
+      hashAlgorithm: getHashAlgorithmName(tstInfo.messageImprint.hashAlgorithm.algorithm),
+      messageImprint: bufferToHex(tstInfo.messageImprint.hashedMessage.buffer),
+      tsaName,
+      tsaCertificate,
+      accuracy,
+    };
+  } catch (error) {
+    console.error(
+      "Failed to parse timestamp:",
+      error instanceof Error ? error.message : String(error),
+    );
+    return null;
+  }
+}
+
+/**
+ * Compute hash of data using Web Crypto API
+ */
+async function computeHash(data: ArrayBuffer, algorithm: string): Promise<ArrayBuffer> {
+  const algoMap: Record<string, string> = {
+    "SHA-1": "SHA-1",
+    "SHA-256": "SHA-256",
+    "SHA-384": "SHA-384",
+    "SHA-512": "SHA-512",
+  };
+
+  const webCryptoAlgo = algoMap[algorithm];
+  if (!webCryptoAlgo) {
+    throw new Error(`Unsupported hash algorithm: ${algorithm}`);
+  }
+
+  if (typeof crypto !== "undefined" && crypto.subtle) {
+    return crypto.subtle.digest(webCryptoAlgo, data);
+  }
+
+  // Node.js fallback
+  const nodeCrypto = require("crypto");
+  const hash = nodeCrypto.createHash(algorithm.toLowerCase().replace("-", ""));
+  hash.update(Buffer.from(data));
+  return hash.digest().buffer;
+}
+
+/**
+ * Verify that timestamp covers the signature value
+ * XAdES timestamps can cover either:
+ * 1. The decoded signature value bytes (standard per ETSI EN 319 132-1)
+ * 2. The base64-encoded string (some implementations)
+ *
+ * @param timestampInfo Parsed timestamp info
+ * @param signatureValueBase64 Base64-encoded signature value
+ * @returns True if the timestamp covers the signature
+ */
+export async function verifyTimestampCoversSignature(
+  timestampInfo: TimestampInfo,
+  signatureValueBase64: string,
+): Promise<boolean> {
+  try {
+    const messageImprintLower = timestampInfo.messageImprint.toLowerCase();
+
+    // Try 1: Hash of decoded signature value bytes (standard approach)
+    const signatureValue = base64ToBuffer(signatureValueBase64);
+    const computedHash = await computeHash(signatureValue, timestampInfo.hashAlgorithm);
+    const computedHashHex = bufferToHex(computedHash);
+
+    if (computedHashHex.toLowerCase() === messageImprintLower) {
+      return true;
+    }
+
+    // Try 2: Hash of base64 string (some implementations)
+    const encoder = new TextEncoder();
+    const base64Bytes = encoder.encode(signatureValueBase64);
+    const base64Hash = await computeHash(
+      base64Bytes.buffer as ArrayBuffer,
+      timestampInfo.hashAlgorithm,
+    );
+    const base64HashHex = bufferToHex(base64Hash);
+
+    if (base64HashHex.toLowerCase() === messageImprintLower) {
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    console.error(
+      "Failed to verify timestamp coverage:",
+      error instanceof Error ? error.message : String(error),
+    );
+    return false;
+  }
+}
+
+/**
+ * Verify an RFC 3161 timestamp token
+ * @param timestampBase64 Base64-encoded timestamp token
+ * @param options Verification options
+ * @returns Timestamp verification result
+ */
+export async function verifyTimestamp(
+  timestampBase64: string,
+  options: TimestampVerificationOptions = {},
+): Promise<TimestampVerificationResult> {
+  // Parse the timestamp
+  const info = parseTimestamp(timestampBase64);
+  if (!info) {
+    return {
+      isValid: false,
+      reason: "Failed to parse timestamp token",
+    };
+  }
+
+  // Verify timestamp covers the signature if provided
+  // Note: coversSignature failure is informational - the timestamp is still valid
+  // and can be used for genTime. The signature value hashing varies by implementation.
+  let coversSignature: boolean | undefined;
+  let coversSignatureReason: string | undefined;
+  if (options.signatureValue) {
+    coversSignature = await verifyTimestampCoversSignature(info, options.signatureValue);
+    if (!coversSignature) {
+      coversSignatureReason =
+        "Could not verify timestamp covers signature (implementation-specific hashing)";
+    }
+  }
+
+  // Verify TSA certificate if requested
+  if (options.verifyTsaCertificate && info.tsaCertificate) {
+    try {
+      const tsaCert = new X509Certificate(info.tsaCertificate);
+
+      // Check TSA certificate was valid at timestamp generation time
+      if (info.genTime < tsaCert.notBefore || info.genTime > tsaCert.notAfter) {
+        return {
+          isValid: false,
+          info,
+          coversSignature,
+          reason: `TSA certificate was not valid at timestamp time (${info.genTime.toISOString()})`,
+        };
+      }
+
+      // TODO: Verify TSA certificate chain and revocation if checkTsaRevocation is true
+    } catch (error) {
+      return {
+        isValid: false,
+        info,
+        coversSignature,
+        reason: `Failed to verify TSA certificate: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  return {
+    isValid: true,
+    info,
+    coversSignature,
+    reason: coversSignatureReason,
+  };
+}
+
+/**
+ * Get the trusted timestamp time from a signature
+ * This should be used instead of the self-declared signingTime for certificate validation
+ * @param timestampBase64 Base64-encoded timestamp token
+ * @returns The timestamp generation time, or null if parsing fails
+ */
+export function getTimestampTime(timestampBase64: string): Date | null {
+  const info = parseTimestamp(timestampBase64);
+  return info?.genTime || null;
+}

--- a/src/core/verification.ts
+++ b/src/core/verification.ts
@@ -9,6 +9,7 @@ import { checkCertificateRevocation } from "./revocation/check";
 import { RevocationResult, RevocationCheckOptions } from "./revocation/types";
 import { verifyTimestamp, getTimestampTime } from "./timestamp/verify";
 import { TimestampVerificationResult } from "./timestamp/types";
+import { base64ToUint8Array } from "../utils/encoding";
 
 /**
  * Options for verification process
@@ -342,27 +343,6 @@ function getCryptoSubtle(): SubtleCrypto {
   } else {
     // In Node.js environment
     return crypto.subtle;
-  }
-}
-
-/**
- * Base64 decode a string in a cross-platform way
- * @param base64 Base64 encoded string
- * @returns Uint8Array of decoded bytes
- */
-function base64ToUint8Array(base64: string): Uint8Array {
-  if (typeof atob === "function") {
-    // Browser approach
-    const binaryString = atob(base64);
-    const bytes = new Uint8Array(binaryString.length);
-    for (let i = 0; i < binaryString.length; i++) {
-      bytes[i] = binaryString.charCodeAt(i);
-    }
-    return bytes;
-  } else {
-    // Node.js approach
-    const buffer = Buffer.from(base64, "base64");
-    return new Uint8Array(buffer);
   }
 }
 

--- a/src/core/verification.ts
+++ b/src/core/verification.ts
@@ -6,7 +6,7 @@ import { XMLCanonicalizer, CANONICALIZATION_METHODS } from "./canonicalization/X
 import { SignatureInfo } from "./parser";
 import { fixRSAModulusPadding } from "./rsa-modulus-padding-fix";
 import { checkCertificateRevocation } from "./revocation/check";
-import { RevocationResult } from "./revocation/types";
+import { RevocationResult, RevocationCheckOptions } from "./revocation/types";
 import { verifyTimestamp, getTimestampTime } from "./timestamp/verify";
 import { TimestampVerificationResult } from "./timestamp/types";
 
@@ -20,6 +20,8 @@ export interface VerificationOptions {
   verifyTime?: Date;
   /** Check certificate revocation via OCSP/CRL (default: true) */
   checkRevocation?: boolean;
+  /** Options for revocation checking (timeouts, etc.) */
+  revocationOptions?: RevocationCheckOptions;
   /** Verify RFC 3161 timestamp if present (default: true) */
   verifyTimestamps?: boolean;
 }
@@ -536,6 +538,7 @@ export async function verifySignature(
     try {
       const revocationResult = await checkCertificateRevocation(signatureInfo.certificatePEM, {
         certificateChain: signatureInfo.certificateChain,
+        ...options.revocationOptions,
       });
 
       certResult.revocation = revocationResult;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,18 +5,10 @@ import {
 } from "./core/canonicalization/XMLCanonicalizer";
 import { parseCertificate, getSignerDisplayName, formatValidityPeriod } from "./core/certificate";
 import { verifyChecksums, verifySignature } from "./core/verification";
-import {
-  checkCertificateRevocation,
-  RevocationResult,
-  RevocationCheckOptions,
-} from "./core/revocation";
-import {
-  parseTimestamp,
-  verifyTimestamp,
-  getTimestampTime,
-  TimestampInfo,
-  TimestampVerificationResult,
-} from "./core/timestamp";
+import { checkCertificateRevocation } from "./core/revocation/check";
+import { RevocationResult, RevocationCheckOptions } from "./core/revocation/types";
+import { parseTimestamp, verifyTimestamp, getTimestampTime } from "./core/timestamp/verify";
+import { TimestampInfo, TimestampVerificationResult } from "./core/timestamp/types";
 
 export {
   // Core functionality

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,13 @@ import {
   RevocationResult,
   RevocationCheckOptions,
 } from "./core/revocation";
+import {
+  parseTimestamp,
+  verifyTimestamp,
+  getTimestampTime,
+  TimestampInfo,
+  TimestampVerificationResult,
+} from "./core/timestamp";
 
 export {
   // Core functionality
@@ -33,4 +40,11 @@ export {
   checkCertificateRevocation,
   RevocationResult,
   RevocationCheckOptions,
+
+  // Timestamp verification
+  parseTimestamp,
+  verifyTimestamp,
+  getTimestampTime,
+  TimestampInfo,
+  TimestampVerificationResult,
 };

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -1,10 +1,10 @@
 /**
- * Cross-platform encoding utilities
+ * Cross-platform encoding utilities for ArrayBuffer/Base64/Hex conversions
+ * Works in both browser and Node.js environments
  */
 
 /**
- * Convert ArrayBuffer to base64 string (cross-platform)
- * Works in both browser and Node.js environments
+ * Convert ArrayBuffer to base64 string
  */
 export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
@@ -18,4 +18,58 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   }
   // Node.js
   return Buffer.from(bytes).toString("base64");
+}
+
+/**
+ * Convert base64 string to ArrayBuffer
+ */
+export function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  if (typeof atob === "function") {
+    // Browser
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+  // Node.js
+  const buffer = Buffer.from(base64, "base64");
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+}
+
+/**
+ * Convert base64 string to Uint8Array
+ */
+export function base64ToUint8Array(base64: string): Uint8Array {
+  return new Uint8Array(base64ToArrayBuffer(base64));
+}
+
+/**
+ * Convert ArrayBuffer to hex string
+ */
+export function arrayBufferToHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Convert hex string to ArrayBuffer
+ */
+export function hexToArrayBuffer(hex: string): ArrayBuffer {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes.buffer;
+}
+
+/**
+ * Format DER bytes as PEM certificate
+ */
+export function arrayBufferToPEM(buffer: ArrayBuffer, type: string = "CERTIFICATE"): string {
+  const base64 = arrayBufferToBase64(buffer);
+  const lines = base64.match(/.{1,64}/g) || [];
+  return `-----BEGIN ${type}-----\n${lines.join("\n")}\n-----END ${type}-----`;
 }

--- a/tests-browser/timestamp.spec.ts
+++ b/tests-browser/timestamp.spec.ts
@@ -1,0 +1,270 @@
+import { expect } from "@esm-bundle/chai";
+import { parseEdoc } from "../src/core/parser";
+import { parseTimestamp, verifyTimestamp, getTimestampTime } from "../src/core/timestamp/verify";
+import { verifySignature } from "../src/core/verification";
+
+describe("RFC 3161 Timestamp Verification (Browser)", () => {
+  const samplePath = "/tests/fixtures/valid_samples/SampleFile.edoc";
+
+  let container: ReturnType<typeof parseEdoc>;
+
+  before(async function () {
+    try {
+      const response = await fetch(samplePath);
+      if (!response.ok) {
+        console.error(`Failed to fetch ${samplePath}: ${response.status} ${response.statusText}`);
+        this.skip();
+        return;
+      }
+
+      const buffer = await response.arrayBuffer();
+      container = parseEdoc(new Uint8Array(buffer));
+      expect(container.signatures.length).to.be.greaterThan(0);
+    } catch (error) {
+      console.error("Error setting up timestamp tests:", error);
+      this.skip();
+    }
+  });
+
+  describe("Timestamp extraction", () => {
+    it("should extract signature timestamp if present", function () {
+      if (!container || container.signatures.length === 0) {
+        this.skip();
+        return;
+      }
+
+      const sig = container.signatures[0];
+      if (sig.signatureTimestamp) {
+        expect(typeof sig.signatureTimestamp).to.equal("string");
+        expect(sig.signatureTimestamp.length).to.be.greaterThan(100);
+        console.log("Signature timestamp found, length:", sig.signatureTimestamp.length);
+      } else {
+        console.log("No signature timestamp in sample file - skipping timestamp tests");
+      }
+    });
+  });
+
+  describe("Timestamp parsing", () => {
+    it("should parse timestamp token if present", function () {
+      if (!container || container.signatures.length === 0) {
+        this.skip();
+        return;
+      }
+
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        console.log("Skipping test - no timestamp in sample file");
+        this.skip();
+        return;
+      }
+
+      const timestampInfo = parseTimestamp(sig.signatureTimestamp);
+      expect(timestampInfo).to.not.be.null;
+
+      if (timestampInfo) {
+        console.log("Parsed timestamp info:", {
+          genTime: timestampInfo.genTime.toISOString(),
+          policy: timestampInfo.policy,
+          hashAlgorithm: timestampInfo.hashAlgorithm,
+          tsaName: timestampInfo.tsaName,
+          hasTsaCertificate: !!timestampInfo.tsaCertificate,
+        });
+
+        expect(timestampInfo.genTime).to.be.instanceOf(Date);
+        expect(typeof timestampInfo.policy).to.equal("string");
+        expect(typeof timestampInfo.hashAlgorithm).to.equal("string");
+        expect(typeof timestampInfo.messageImprint).to.equal("string");
+      }
+    });
+
+    it("should have valid generation time", function () {
+      if (!container || container.signatures.length === 0) {
+        this.skip();
+        return;
+      }
+
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        this.skip();
+        return;
+      }
+
+      const timestampInfo = parseTimestamp(sig.signatureTimestamp);
+      expect(timestampInfo).to.not.be.null;
+
+      if (timestampInfo) {
+        // Timestamp generation time should be reasonable
+        expect(timestampInfo.genTime.getTime()).to.be.lessThan(Date.now());
+        expect(timestampInfo.genTime.getTime()).to.be.greaterThan(new Date("2000-01-01").getTime());
+      }
+    });
+  });
+
+  describe("getTimestampTime utility", () => {
+    it("should extract timestamp time", function () {
+      if (!container || container.signatures.length === 0) {
+        this.skip();
+        return;
+      }
+
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        this.skip();
+        return;
+      }
+
+      const time = getTimestampTime(sig.signatureTimestamp);
+      expect(time).to.be.instanceOf(Date);
+      console.log("Timestamp time:", time?.toISOString());
+    });
+
+    it("should return null for invalid timestamp", function () {
+      const time = getTimestampTime("invalid-base64");
+      expect(time).to.be.null;
+    });
+  });
+
+  describe("Timestamp verification", () => {
+    it("should verify timestamp with signature value", async function () {
+      if (!container || container.signatures.length === 0) {
+        this.skip();
+        return;
+      }
+
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        console.log("Skipping test - no timestamp in sample file");
+        this.skip();
+        return;
+      }
+
+      const result = await verifyTimestamp(sig.signatureTimestamp, {
+        signatureValue: sig.signatureValue,
+        verifyTsaCertificate: true,
+        checkTsaRevocation: false, // Disable for faster test
+      });
+
+      console.log("Timestamp verification result:", {
+        isValid: result.isValid,
+        coversSignature: result.coversSignature,
+        reason: result.reason,
+        genTime: result.info?.genTime?.toISOString(),
+      });
+
+      expect(result).to.have.property("isValid");
+      expect(result).to.have.property("info");
+    });
+
+    it("should verify timestamp with TSA revocation check", async function () {
+      if (!container || container.signatures.length === 0) {
+        this.skip();
+        return;
+      }
+
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        console.log("Skipping test - no timestamp in sample file");
+        this.skip();
+        return;
+      }
+
+      const result = await verifyTimestamp(sig.signatureTimestamp, {
+        signatureValue: sig.signatureValue,
+        verifyTsaCertificate: true,
+        checkTsaRevocation: true,
+      });
+
+      console.log("Timestamp verification with TSA revocation:", {
+        isValid: result.isValid,
+        coversSignature: result.coversSignature,
+        tsaRevocationStatus: result.tsaRevocation?.status,
+        tsaRevocationMethod: result.tsaRevocation?.method,
+        reason: result.reason,
+      });
+
+      expect(result).to.have.property("isValid");
+      expect(result).to.have.property("info");
+
+      // If TSA revocation was checked, we should have a result
+      if (result.tsaRevocation) {
+        expect(["good", "revoked", "unknown", "error"]).to.contain(result.tsaRevocation.status);
+      }
+    });
+  });
+
+  describe("Timestamp in verification flow", () => {
+    it("should include timestamp result when verifyTimestamps is true", async function () {
+      if (!container || container.signatures.length === 0) {
+        this.skip();
+        return;
+      }
+
+      const sig = container.signatures[0];
+      const result = await verifySignature(sig, container.files, {
+        checkRevocation: false, // Disable for faster test
+        verifyTimestamps: true,
+      });
+
+      if (sig.signatureTimestamp) {
+        expect(result.timestamp).to.not.be.undefined;
+        expect(result.timestamp?.isValid).to.not.be.undefined;
+        console.log("Verification timestamp result:", {
+          isValid: result.timestamp?.isValid,
+          coversSignature: result.timestamp?.coversSignature,
+          genTime: result.timestamp?.info?.genTime?.toISOString(),
+        });
+      } else {
+        console.log("No timestamp to verify in sample file");
+      }
+    });
+
+    it("should skip timestamp when verifyTimestamps is false", async function () {
+      if (!container || container.signatures.length === 0) {
+        this.skip();
+        return;
+      }
+
+      const sig = container.signatures[0];
+      const result = await verifySignature(sig, container.files, {
+        checkRevocation: false,
+        verifyTimestamps: false,
+      });
+
+      expect(result.timestamp).to.be.undefined;
+    });
+
+    it("should use timestamp time for certificate validation", async function () {
+      if (!container || container.signatures.length === 0) {
+        this.skip();
+        return;
+      }
+
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        console.log("Skipping test - no timestamp in sample file");
+        this.skip();
+        return;
+      }
+
+      // Get the timestamp time
+      const timestampTime = getTimestampTime(sig.signatureTimestamp);
+
+      // Verify with timestamp checking enabled (should use TSA time for cert validation)
+      const result = await verifySignature(sig, container.files, {
+        checkRevocation: false,
+        verifyTimestamps: true,
+      });
+
+      console.log("Certificate validated at timestamp time:", {
+        timestampTime: timestampTime?.toISOString(),
+        certValid: result.certificate.isValid,
+        overallValid: result.isValid,
+      });
+
+      // Certificate should be valid at the timestamp time
+      if (timestampTime && result.isValid) {
+        expect(result.certificate.isValid).to.be.true;
+      }
+    });
+  });
+});

--- a/tests/integration/timestamp.test.ts
+++ b/tests/integration/timestamp.test.ts
@@ -1,0 +1,186 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parseEdoc } from "../../src/core/parser";
+import { verifySignature } from "../../src/core/verification";
+import {
+  parseTimestamp,
+  verifyTimestamp,
+  verifyTimestampCoversSignature,
+  getTimestampTime,
+} from "../../src/core/timestamp";
+
+const sampleFilePath = join(__dirname, "../fixtures/valid_samples/SampleFile.edoc");
+
+describe("RFC 3161 Timestamp Verification", () => {
+  let container: ReturnType<typeof parseEdoc>;
+
+  beforeAll(() => {
+    const edocBuffer = readFileSync(sampleFilePath);
+    container = parseEdoc(edocBuffer);
+    expect(container.signatures.length).toBeGreaterThan(0);
+  });
+
+  describe("Timestamp extraction", () => {
+    it("should parse the sample file successfully", () => {
+      expect(container).toBeDefined();
+      expect(container.signatures.length).toBeGreaterThan(0);
+    });
+
+    it("should extract signature timestamp if present", () => {
+      const sig = container.signatures[0];
+      // Timestamp may or may not be present depending on the file
+      if (sig.signatureTimestamp) {
+        expect(typeof sig.signatureTimestamp).toBe("string");
+        // Base64 encoded timestamp should have reasonable length
+        expect(sig.signatureTimestamp.length).toBeGreaterThan(100);
+        console.log("Signature timestamp found, length:", sig.signatureTimestamp.length);
+      } else {
+        console.log("No signature timestamp in sample file");
+      }
+    });
+  });
+
+  describe("Timestamp parsing", () => {
+    it("should parse timestamp token if present", () => {
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        console.log("Skipping test - no timestamp in sample file");
+        return;
+      }
+
+      const timestampInfo = parseTimestamp(sig.signatureTimestamp);
+      expect(timestampInfo).not.toBeNull();
+
+      if (timestampInfo) {
+        console.log("Parsed timestamp info:", {
+          genTime: timestampInfo.genTime,
+          policy: timestampInfo.policy,
+          hashAlgorithm: timestampInfo.hashAlgorithm,
+          tsaName: timestampInfo.tsaName,
+          serialNumber: timestampInfo.serialNumber.substring(0, 20) + "...",
+        });
+
+        // Verify timestamp has required fields
+        expect(timestampInfo.genTime).toBeInstanceOf(Date);
+        expect(typeof timestampInfo.policy).toBe("string");
+        expect(typeof timestampInfo.hashAlgorithm).toBe("string");
+        expect(typeof timestampInfo.messageImprint).toBe("string");
+        expect(typeof timestampInfo.serialNumber).toBe("string");
+      }
+    });
+
+    it("should have valid generation time", () => {
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        console.log("Skipping test - no timestamp in sample file");
+        return;
+      }
+
+      const timestampInfo = parseTimestamp(sig.signatureTimestamp);
+      expect(timestampInfo).not.toBeNull();
+
+      if (timestampInfo) {
+        // Timestamp generation time should be a reasonable date (not in the future)
+        expect(timestampInfo.genTime.getTime()).toBeLessThanOrEqual(Date.now());
+        // Should be after year 2000
+        expect(timestampInfo.genTime.getTime()).toBeGreaterThan(new Date("2000-01-01").getTime());
+      }
+    });
+  });
+
+  describe("Timestamp verification", () => {
+    it("should verify timestamp covers signature", async () => {
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp || !sig.signatureValue) {
+        console.log("Skipping test - no timestamp or signature value");
+        return;
+      }
+
+      const timestampInfo = parseTimestamp(sig.signatureTimestamp);
+      if (!timestampInfo) {
+        console.log("Skipping test - could not parse timestamp");
+        return;
+      }
+
+      const coversSignature = await verifyTimestampCoversSignature(
+        timestampInfo,
+        sig.signatureValue,
+      );
+
+      console.log("Timestamp covers signature:", coversSignature);
+      expect(typeof coversSignature).toBe("boolean");
+    });
+
+    it("should verify timestamp with signature value", async () => {
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        console.log("Skipping test - no timestamp in sample file");
+        return;
+      }
+
+      const result = await verifyTimestamp(sig.signatureTimestamp, {
+        signatureValue: sig.signatureValue,
+      });
+
+      console.log("Timestamp verification result:", {
+        isValid: result.isValid,
+        coversSignature: result.coversSignature,
+        reason: result.reason,
+      });
+
+      expect(result).toHaveProperty("isValid");
+      expect(result).toHaveProperty("info");
+    });
+  });
+
+  describe("getTimestampTime utility", () => {
+    it("should extract timestamp time", () => {
+      const sig = container.signatures[0];
+      if (!sig.signatureTimestamp) {
+        console.log("Skipping test - no timestamp in sample file");
+        return;
+      }
+
+      const time = getTimestampTime(sig.signatureTimestamp);
+      expect(time).toBeInstanceOf(Date);
+      console.log("Timestamp time:", time);
+    });
+
+    it("should return null for invalid timestamp", () => {
+      const time = getTimestampTime("invalid-base64");
+      expect(time).toBeNull();
+    });
+  });
+
+  describe("Timestamp in verification flow", () => {
+    it("should include timestamp result when verifyTimestamps is true", async () => {
+      const sig = container.signatures[0];
+      const result = await verifySignature(sig, container.files, {
+        checkRevocation: false,
+        verifyTimestamps: true,
+      });
+
+      if (sig.signatureTimestamp) {
+        expect(result.timestamp).toBeDefined();
+        expect(result.timestamp?.isValid).toBeDefined();
+        console.log("Verification timestamp result:", {
+          isValid: result.timestamp?.isValid,
+          coversSignature: result.timestamp?.coversSignature,
+          genTime: result.timestamp?.info?.genTime,
+        });
+      } else {
+        console.log("No timestamp to verify in sample file");
+      }
+    });
+
+    it("should skip timestamp when verifyTimestamps is false", async () => {
+      const sig = container.signatures[0];
+      const result = await verifySignature(sig, container.files, {
+        checkRevocation: false,
+        verifyTimestamps: false,
+      });
+
+      expect(result.timestamp).toBeUndefined();
+    });
+  });
+});

--- a/tests/integration/timestamp.test.ts
+++ b/tests/integration/timestamp.test.ts
@@ -7,7 +7,7 @@ import {
   verifyTimestamp,
   verifyTimestampCoversSignature,
   getTimestampTime,
-} from "../../src/core/timestamp";
+} from "../../src/core/timestamp/verify";
 
 const sampleFilePath = join(__dirname, "../fixtures/valid_samples/SampleFile.edoc");
 


### PR DESCRIPTION
  Add RFC 3161 timestamp verification with TSA revocation checking

  - Parse and verify RFC 3161 timestamps (SignatureTimeStamp)
  - Check TSA certificate validity and revocation (OCSP/CRL)
  - Use trusted TSA time for signer certificate validation
  - Add revocationOptions pass-through to verifySignature
  - Fix browser-compatible imports (direct paths vs barrel imports)
  - Refactor: consolidate encoding utilities (base64/hex/ArrayBuffer)
  - Add browser tests for timestamp functionality
  - Update README with timestamp API and revocationOptions docs