### PR TITLE
Add CORS proxy support for OCSP/CRL requests

### DIFF
--- a/src/core/revocation/check.ts
+++ b/src/core/revocation/check.ts
@@ -52,6 +52,7 @@ export async function checkCertificateRevocation(
     ocspResult = await checkOCSP(x509Cert, null, {
       timeout: opts.ocspTimeout,
       certificateChain: opts.certificateChain,
+      proxyUrl: options.proxyUrl,
     });
 
     // If OCSP gives a definitive answer (good or revoked), use it
@@ -66,6 +67,7 @@ export async function checkCertificateRevocation(
   if (opts.crlEnabled) {
     crlResult = await checkCRL(x509Cert, {
       timeout: opts.crlTimeout,
+      proxyUrl: options.proxyUrl,
     });
 
     // If CRL gives a definitive answer, use it

--- a/src/core/revocation/crl.ts
+++ b/src/core/revocation/crl.ts
@@ -106,9 +106,9 @@ export function parseCRL(data: ArrayBuffer): X509Crl | null {
  */
 export async function checkCRL(
   cert: X509Certificate,
-  options: { timeout?: number } = {},
+  options: { timeout?: number; proxyUrl?: string } = {},
 ): Promise<RevocationResult> {
-  const { timeout = 10000 } = options;
+  const { timeout = 10000, proxyUrl } = options;
   const now = new Date();
 
   // Get CRL URLs
@@ -128,7 +128,7 @@ export async function checkCRL(
 
   for (const url of crlUrls) {
     try {
-      const result = await fetchCRL(url, timeout);
+      const result = await fetchCRL(url, timeout, proxyUrl);
 
       if (!result.ok || !result.data) {
         errors.push(`${url}: ${result.error || "Failed to fetch"}`);

--- a/src/core/revocation/types.ts
+++ b/src/core/revocation/types.ts
@@ -32,13 +32,20 @@ export interface RevocationCheckOptions {
   crlTimeout?: number;
   /** Certificate chain for finding issuer (PEM strings) */
   certificateChain?: string[];
+  /**
+   * CORS proxy URL for browser environments.
+   * When set, all OCSP/CRL fetch requests will be routed through this proxy.
+   * The original URL will be URL-encoded and appended as a query parameter.
+   * Example: "https://cors-proxy.example.com/?url="
+   */
+  proxyUrl?: string;
 }
 
 /**
  * Default options for revocation checking
  */
 export const DEFAULT_REVOCATION_OPTIONS: Required<
-  Omit<RevocationCheckOptions, "certificateChain">
+  Omit<RevocationCheckOptions, "certificateChain" | "proxyUrl">
 > = {
   ocspEnabled: true,
   crlEnabled: true,

--- a/tests/unit/core/revocation/fetch.test.ts
+++ b/tests/unit/core/revocation/fetch.test.ts
@@ -1,0 +1,211 @@
+import {
+  fetchBinary,
+  fetchOCSP,
+  fetchCRL,
+  fetchIssuerCertificate,
+} from "../../../../src/core/revocation/fetch";
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe("revocation/fetch", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("fetchBinary", () => {
+    it("should fetch directly when no proxyUrl is provided", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchBinary("http://example.com/file.crl");
+
+      expect(mockFetch).toHaveBeenCalledWith("http://example.com/file.crl", expect.any(Object));
+    });
+
+    it("should route through proxy when proxyUrl is provided", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchBinary("http://example.com/file.crl", {
+        proxyUrl: "https://proxy.example.com/?url=",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://proxy.example.com/?url=http%3A%2F%2Fexample.com%2Ffile.crl",
+        expect.any(Object),
+      );
+    });
+
+    it("should URL-encode the original URL when using proxy", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const originalUrl = "http://example.com/path?param=value&other=123";
+      await fetchBinary(originalUrl, {
+        proxyUrl: "https://cors-proxy.workers.dev/?url=",
+      });
+
+      const expectedProxiedUrl =
+        "https://cors-proxy.workers.dev/?url=" + encodeURIComponent(originalUrl);
+      expect(mockFetch).toHaveBeenCalledWith(expectedProxiedUrl, expect.any(Object));
+    });
+
+    it("should return error on network failure", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+
+      const result = await fetchBinary("http://example.com/file.crl");
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("Network error");
+    });
+
+    it("should return error on HTTP error status", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await fetchBinary("http://example.com/file.crl");
+
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(404);
+      expect(result.error).toBe("HTTP 404: Not Found");
+    });
+  });
+
+  describe("fetchOCSP", () => {
+    it("should pass proxyUrl to fetchBinary", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const request = new ArrayBuffer(100);
+      await fetchOCSP("http://ocsp.example.com", request, 5000, "https://proxy.example.com/?url=");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://proxy.example.com/?url=http%3A%2F%2Focsp.example.com",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    it("should fetch directly when proxyUrl is undefined", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const request = new ArrayBuffer(100);
+      await fetchOCSP("http://ocsp.example.com", request, 5000);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://ocsp.example.com",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+  });
+
+  describe("fetchCRL", () => {
+    it("should pass proxyUrl to fetchBinary", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchCRL("http://crl.example.com/ca.crl", 10000, "https://proxy.example.com/?url=");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://proxy.example.com/?url=http%3A%2F%2Fcrl.example.com%2Fca.crl",
+        expect.objectContaining({
+          method: "GET",
+        }),
+      );
+    });
+
+    it("should fetch directly when proxyUrl is undefined", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchCRL("http://crl.example.com/ca.crl", 10000);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://crl.example.com/ca.crl",
+        expect.objectContaining({
+          method: "GET",
+        }),
+      );
+    });
+  });
+
+  describe("fetchIssuerCertificate", () => {
+    it("should pass proxyUrl to fetchBinary", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchIssuerCertificate(
+        "http://ca.example.com/issuer.crt",
+        5000,
+        "https://proxy.example.com/?url=",
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://proxy.example.com/?url=http%3A%2F%2Fca.example.com%2Fissuer.crt",
+        expect.objectContaining({
+          method: "GET",
+        }),
+      );
+    });
+
+    it("should fetch directly when proxyUrl is undefined", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchIssuerCertificate("http://ca.example.com/issuer.crt", 5000);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://ca.example.com/issuer.crt",
+        expect.objectContaining({
+          method: "GET",
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Add proxyUrl option to revocationOptions for routing OCSP, CRL, and CA issuer certificate requests through a CORS proxy in browser environments.
- Add proxyUrl to RevocationCheckOptions
- Update fetch functions to rewrite URLs through proxy when set
- Add unit tests for proxy URL functionality