### PR TITLE
Verification bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2025-12-31
+
+### Fixed
+
+- **OCSP issuerKeyHash calculation** - Fixed critical bug where OCSP requests used wrong hash (full SPKI instead of public key BIT STRING), causing incorrect revocation status responses
+
 ## [0.2.3] - 2025-12-30
 
 ### Fixed
@@ -60,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File checksum verification (SHA-256/384/512)
 - Browser and Node.js support
 
+[0.2.4]: https://github.com/edgarsj/edockit/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/edgarsj/edockit/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/edgarsj/edockit/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/edgarsj/edockit/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Timestamp signature coverage verification** - Now correctly verifies that timestamps cover the canonicalized ds:SignatureValue XML element per XAdES (ETSI EN 319 132-1) specification, fixing `coversSignature: false` issue
 - **TSA name formatting** - Fixed timestamp TSA name showing as `[object Object]` instead of readable DN string like `CN=..., O=..., C=...`
 - **Base64 whitespace handling** - Fixed browser `atob` errors when decoding base64 strings containing whitespace from XML
+- **ECDSA signature format normalization** - Fixed signature verification failures for ECDSA signatures with leading zero padding by normalizing to IEEE P1363 format expected by Web Crypto API
 
 ## [0.2.3] - 2025-12-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **OCSP issuerKeyHash calculation** - Fixed critical bug where OCSP requests used wrong hash (full SPKI instead of public key BIT STRING), causing incorrect revocation status responses
+- **Timestamp signature coverage verification** - Now correctly verifies that timestamps cover the canonicalized ds:SignatureValue XML element per XAdES (ETSI EN 319 132-1) specification, fixing `coversSignature: false` issue
+- **TSA name formatting** - Fixed timestamp TSA name showing as `[object Object]` instead of readable DN string like `CN=..., O=..., C=...`
+- **Base64 whitespace handling** - Fixed browser `atob` errors when decoding base64 strings containing whitespace from XML
 
 ## [0.2.3] - 2025-12-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edockit",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "dist/index.cjs.js",
   "scripts": {
     "test": "jest --silent",

--- a/src/core/parser/types.ts
+++ b/src/core/parser/types.ts
@@ -38,6 +38,7 @@ export interface SignatureInfo {
   references: string[]; // Filenames referenced by this signature
   algorithm?: string; // Signature algorithm URI
   signatureValue?: string; // Base64 signature value
+  canonicalSignatureValue?: string; // Canonicalized ds:SignatureValue element (for timestamp verification)
   signedInfoXml?: string; // The XML string of the SignedInfo element
   rawXml?: string; // The full raw XML of the signature
   canonicalizationMethod?: string; // The canonicalization method used

--- a/src/core/timestamp/types.ts
+++ b/src/core/timestamp/types.ts
@@ -44,8 +44,8 @@ export interface TimestampVerificationResult {
  * Options for timestamp verification
  */
 export interface TimestampVerificationOptions {
-  /** The signature value that the timestamp should cover (base64) */
-  signatureValue?: string;
+  /** The canonicalized ds:SignatureValue XML element (per XAdES spec) */
+  canonicalSignatureValue?: string;
   /** Verify the TSA certificate chain */
   verifyTsaCertificate?: boolean;
   /** Check TSA certificate revocation */

--- a/src/core/timestamp/verify.ts
+++ b/src/core/timestamp/verify.ts
@@ -275,7 +275,7 @@ export async function verifyTimestamp(
             };
           }
           // Note: 'unknown' status is a soft fail - timestamp remains valid
-          // but user can check tsaRevocation.status to see if it couldn't be verified
+          // but user can check tsaRevocation.status to see the actual status
         } catch (error) {
           // Revocation check failed - soft fail, add to result but don't invalidate
           tsaRevocation = {

--- a/src/core/timestamp/verify.ts
+++ b/src/core/timestamp/verify.ts
@@ -4,6 +4,7 @@ import { X509Certificate } from "@peculiar/x509";
 import { AsnConvert } from "@peculiar/asn1-schema";
 import { ContentInfo, SignedData } from "@peculiar/asn1-cms";
 import { TSTInfo } from "@peculiar/asn1-tsp";
+import { Name } from "@peculiar/asn1-x509";
 import { TimestampInfo, TimestampVerificationResult, TimestampVerificationOptions } from "./types";
 import { checkCertificateRevocation } from "../revocation/check";
 import { RevocationResult } from "../revocation/types";
@@ -35,6 +36,40 @@ function getHashAlgorithmName(oid: string): string {
     "2.16.840.1.101.3.4.2.3": "SHA-512",
   };
   return hashAlgorithms[oid] || oid;
+}
+
+/**
+ * Common OID to attribute name mappings for X.500 distinguished names
+ */
+const oidToAttributeName: Record<string, string> = {
+  "2.5.4.3": "CN",
+  "2.5.4.6": "C",
+  "2.5.4.7": "L",
+  "2.5.4.8": "ST",
+  "2.5.4.10": "O",
+  "2.5.4.11": "OU",
+  "2.5.4.5": "serialNumber",
+  "1.2.840.113549.1.9.1": "emailAddress",
+};
+
+/**
+ * Format an X.500 Name (directoryName) to a readable string
+ * @param name The Name object to format
+ * @returns Formatted string like "CN=Example, O=Company, C=US"
+ */
+function formatDirectoryName(name: Name): string {
+  const parts: string[] = [];
+  for (const rdn of name) {
+    for (const attr of rdn) {
+      const attrName = oidToAttributeName[attr.type] || attr.type;
+      // attr.value can be various ASN.1 string types
+      const value = attr.value?.toString() || "";
+      if (value) {
+        parts.push(`${attrName}=${value}`);
+      }
+    }
+  }
+  return parts.join(", ");
 }
 
 /**
@@ -99,7 +134,7 @@ export function parseTimestamp(timestampBase64: string): TimestampInfo | null {
     let tsaName: string | undefined;
     if (tstInfo.tsa) {
       if (tstInfo.tsa.directoryName) {
-        tsaName = tstInfo.tsa.directoryName.toString();
+        tsaName = formatDirectoryName(tstInfo.tsa.directoryName);
       } else if (tstInfo.tsa.uniformResourceIdentifier) {
         tsaName = tstInfo.tsa.uniformResourceIdentifier;
       }
@@ -163,44 +198,30 @@ async function computeHash(data: ArrayBuffer, algorithm: string): Promise<ArrayB
 
 /**
  * Verify that timestamp covers the signature value
- * XAdES timestamps can cover either:
- * 1. The decoded signature value bytes (standard per ETSI EN 319 132-1)
- * 2. The base64-encoded string (some implementations)
+ *
+ * Per XAdES (ETSI EN 319 132-1), the SignatureTimeStamp covers the canonicalized
+ * ds:SignatureValue XML element, not just its base64 content.
  *
  * @param timestampInfo Parsed timestamp info
- * @param signatureValueBase64 Base64-encoded signature value
+ * @param canonicalSignatureValue Canonicalized ds:SignatureValue XML element
  * @returns True if the timestamp covers the signature
  */
 export async function verifyTimestampCoversSignature(
   timestampInfo: TimestampInfo,
-  signatureValueBase64: string,
+  canonicalSignatureValue: string,
 ): Promise<boolean> {
   try {
     const messageImprintLower = timestampInfo.messageImprint.toLowerCase();
-
-    // Try 1: Hash of decoded signature value bytes (standard approach)
-    const signatureValue = base64ToArrayBuffer(signatureValueBase64);
-    const computedHash = await computeHash(signatureValue, timestampInfo.hashAlgorithm);
-    const computedHashHex = arrayBufferToHex(computedHash);
-
-    if (computedHashHex.toLowerCase() === messageImprintLower) {
-      return true;
-    }
-
-    // Try 2: Hash of base64 string (some implementations)
     const encoder = new TextEncoder();
-    const base64Bytes = encoder.encode(signatureValueBase64);
-    const base64Hash = await computeHash(
-      base64Bytes.buffer as ArrayBuffer,
+
+    const canonicalBytes = encoder.encode(canonicalSignatureValue);
+    const canonicalHash = await computeHash(
+      canonicalBytes.buffer as ArrayBuffer,
       timestampInfo.hashAlgorithm,
     );
-    const base64HashHex = arrayBufferToHex(base64Hash);
+    const canonicalHashHex = arrayBufferToHex(canonicalHash);
 
-    if (base64HashHex.toLowerCase() === messageImprintLower) {
-      return true;
-    }
-
-    return false;
+    return canonicalHashHex.toLowerCase() === messageImprintLower;
   } catch (error) {
     console.error(
       "Failed to verify timestamp coverage:",
@@ -230,15 +251,12 @@ export async function verifyTimestamp(
   }
 
   // Verify timestamp covers the signature if provided
-  // Note: coversSignature failure is informational - the timestamp is still valid
-  // and can be used for genTime. The signature value hashing varies by implementation.
   let coversSignature: boolean | undefined;
   let coversSignatureReason: string | undefined;
-  if (options.signatureValue) {
-    coversSignature = await verifyTimestampCoversSignature(info, options.signatureValue);
+  if (options.canonicalSignatureValue) {
+    coversSignature = await verifyTimestampCoversSignature(info, options.canonicalSignatureValue);
     if (!coversSignature) {
-      coversSignatureReason =
-        "Could not verify timestamp covers signature (implementation-specific hashing)";
+      coversSignatureReason = "Could not verify timestamp covers signature (hash mismatch)";
     }
   }
 

--- a/src/core/verification.ts
+++ b/src/core/verification.ts
@@ -492,7 +492,7 @@ export async function verifySignature(
 
   if (signatureInfo.signatureTimestamp && options.verifyTimestamps !== false) {
     timestampResult = await verifyTimestamp(signatureInfo.signatureTimestamp, {
-      signatureValue: signatureInfo.signatureValue,
+      canonicalSignatureValue: signatureInfo.canonicalSignatureValue,
       verifyTsaCertificate: true,
       revocationOptions: options.revocationOptions,
     });

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -22,11 +22,15 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
 
 /**
  * Convert base64 string to ArrayBuffer
+ * Handles base64 strings with whitespace (common in XML)
  */
 export function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  // Strip whitespace (newlines, spaces, tabs) that may be present in XML
+  const cleanBase64 = base64.replace(/\s/g, "");
+
   if (typeof atob === "function") {
     // Browser
-    const binary = atob(base64);
+    const binary = atob(cleanBase64);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) {
       bytes[i] = binary.charCodeAt(i);
@@ -34,7 +38,7 @@ export function base64ToArrayBuffer(base64: string): ArrayBuffer {
     return bytes.buffer;
   }
   // Node.js
-  const buffer = Buffer.from(base64, "base64");
+  const buffer = Buffer.from(cleanBase64, "base64");
   return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
 }
 

--- a/tests-browser/timestamp.spec.ts
+++ b/tests-browser/timestamp.spec.ts
@@ -139,7 +139,7 @@ describe("RFC 3161 Timestamp Verification (Browser)", () => {
       }
 
       const result = await verifyTimestamp(sig.signatureTimestamp, {
-        signatureValue: sig.signatureValue,
+        canonicalSignatureValue: sig.canonicalSignatureValue,
         verifyTsaCertificate: true,
         checkTsaRevocation: false, // Disable for faster test
       });
@@ -169,7 +169,7 @@ describe("RFC 3161 Timestamp Verification (Browser)", () => {
       }
 
       const result = await verifyTimestamp(sig.signatureTimestamp, {
-        signatureValue: sig.signatureValue,
+        canonicalSignatureValue: sig.canonicalSignatureValue,
         verifyTsaCertificate: true,
         checkTsaRevocation: true,
       });

--- a/tests/integration/timestamp.test.ts
+++ b/tests/integration/timestamp.test.ts
@@ -91,8 +91,8 @@ describe("RFC 3161 Timestamp Verification", () => {
   describe("Timestamp verification", () => {
     it("should verify timestamp covers signature", async () => {
       const sig = container.signatures[0];
-      if (!sig.signatureTimestamp || !sig.signatureValue) {
-        console.log("Skipping test - no timestamp or signature value");
+      if (!sig.signatureTimestamp || !sig.canonicalSignatureValue) {
+        console.log("Skipping test - no timestamp or canonical signature value");
         return;
       }
 
@@ -104,22 +104,22 @@ describe("RFC 3161 Timestamp Verification", () => {
 
       const coversSignature = await verifyTimestampCoversSignature(
         timestampInfo,
-        sig.signatureValue,
+        sig.canonicalSignatureValue,
       );
 
       console.log("Timestamp covers signature:", coversSignature);
-      expect(typeof coversSignature).toBe("boolean");
+      expect(coversSignature).toBe(true);
     });
 
-    it("should verify timestamp with signature value", async () => {
+    it("should verify timestamp with canonical signature value", async () => {
       const sig = container.signatures[0];
-      if (!sig.signatureTimestamp) {
-        console.log("Skipping test - no timestamp in sample file");
+      if (!sig.signatureTimestamp || !sig.canonicalSignatureValue) {
+        console.log("Skipping test - no timestamp or canonical signature value");
         return;
       }
 
       const result = await verifyTimestamp(sig.signatureTimestamp, {
-        signatureValue: sig.signatureValue,
+        canonicalSignatureValue: sig.canonicalSignatureValue,
       });
 
       console.log("Timestamp verification result:", {
@@ -128,7 +128,8 @@ describe("RFC 3161 Timestamp Verification", () => {
         reason: result.reason,
       });
 
-      expect(result).toHaveProperty("isValid");
+      expect(result.isValid).toBe(true);
+      expect(result.coversSignature).toBe(true);
       expect(result).toHaveProperty("info");
     });
   });


### PR DESCRIPTION
- **OCSP issuerKeyHash calculation** - Fixed critical bug where OCSP requests used wrong hash (full SPKI instead of public key BIT STRING), causing incorrect revocation status responses
- **Timestamp signature coverage verification** - Now correctly verifies that timestamps cover the canonicalized ds:SignatureValue XML element per XAdES (ETSI EN 319 132-1) specification, fixing `coversSignature: false` issue
- **TSA name formatting** - Fixed timestamp TSA name showing as `[object Object]` instead of readable DN string like `CN=..., O=..., C=...`
- **Base64 whitespace handling** - Fixed browser `atob` errors when decoding base64 strings containing whitespace from XML
- **ECDSA signature format normalization** - Fixed signature verification failures for ECDSA signatures with leading zero padding by normalizing to IEEE P1363 format expected by Web Crypto API