### PR TITLE
Handle INDETERMINATE status for expired timestamps + fix legacy RSA DigestInfo verification

### DIFF
--- a/src/core/rsa-digestinfo-workaround.ts
+++ b/src/core/rsa-digestinfo-workaround.ts
@@ -1,0 +1,304 @@
+/**
+ * RSA DigestInfo Workaround
+ *
+ * Some older signing tools (particularly pre-Java 8) produced RSA signatures with
+ * non-standard DigestInfo format - missing the NULL parameter in AlgorithmIdentifier.
+ *
+ * Standard DigestInfo for SHA-1:  30 21 30 09 06 05 2b0e03021a 05 00 04 14 [hash]
+ * Non-standard (missing NULL):    30 1f 30 07 06 05 2b0e03021a       04 14 [hash]
+ *
+ * Web Crypto API's subtle.verify() is strict and rejects the non-standard format.
+ * This module provides a fallback that manually performs RSA verification using
+ * BigInt math, which works in both browser and Node.js environments.
+ */
+
+/**
+ * Parse RSA public key from SPKI format to extract modulus and exponent
+ */
+function parseRSAPublicKey(spkiData: ArrayBuffer): { n: bigint; e: bigint } | null {
+  const bytes = new Uint8Array(spkiData);
+
+  // SPKI structure:
+  // SEQUENCE {
+  //   SEQUENCE { algorithm OID, parameters (NULL or absent) }
+  //   BIT STRING { RSAPublicKey }
+  // }
+  // RSAPublicKey ::= SEQUENCE { modulus INTEGER, publicExponent INTEGER }
+
+  let pos = 0;
+
+  // Helper to read ASN.1 length
+  const readLength = (): number => {
+    const first = bytes[pos++];
+    if ((first & 0x80) === 0) {
+      return first;
+    }
+    const numBytes = first & 0x7f;
+    let length = 0;
+    for (let i = 0; i < numBytes; i++) {
+      length = (length << 8) | bytes[pos++];
+    }
+    return length;
+  };
+
+  // Helper to read INTEGER as BigInt
+  const readInteger = (): bigint => {
+    if (bytes[pos++] !== 0x02) return BigInt(0); // INTEGER tag
+    const len = readLength();
+    let value = BigInt(0);
+    for (let i = 0; i < len; i++) {
+      value = (value << BigInt(8)) | BigInt(bytes[pos++]);
+    }
+    return value;
+  };
+
+  try {
+    // Outer SEQUENCE
+    if (bytes[pos++] !== 0x30) return null;
+    readLength();
+
+    // AlgorithmIdentifier SEQUENCE
+    if (bytes[pos++] !== 0x30) return null;
+    const algoLen = readLength();
+    pos += algoLen; // Skip algorithm identifier
+
+    // BIT STRING containing RSAPublicKey
+    if (bytes[pos++] !== 0x03) return null;
+    readLength();
+    pos++; // Skip unused bits byte
+
+    // RSAPublicKey SEQUENCE
+    if (bytes[pos++] !== 0x30) return null;
+    readLength();
+
+    // Read modulus and exponent
+    const n = readInteger();
+    const e = readInteger();
+
+    return { n, e };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Perform modular exponentiation: base^exp mod mod
+ * Uses square-and-multiply algorithm for efficiency
+ */
+function modPow(base: bigint, exp: bigint, mod: bigint): bigint {
+  let result = BigInt(1);
+  base = base % mod;
+  while (exp > 0) {
+    if (exp % BigInt(2) === BigInt(1)) {
+      result = (result * base) % mod;
+    }
+    exp = exp >> BigInt(1);
+    base = (base * base) % mod;
+  }
+  return result;
+}
+
+/**
+ * Convert Uint8Array to BigInt
+ */
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  let result = BigInt(0);
+  for (const byte of bytes) {
+    result = (result << BigInt(8)) | BigInt(byte);
+  }
+  return result;
+}
+
+/**
+ * Convert BigInt to Uint8Array with specified length
+ */
+function bigIntToBytes(value: bigint, length: number): Uint8Array {
+  const result = new Uint8Array(length);
+  for (let i = length - 1; i >= 0; i--) {
+    result[i] = Number(value & BigInt(0xff));
+    value = value >> BigInt(8);
+  }
+  return result;
+}
+
+/**
+ * Verify PKCS#1 v1.5 signature padding and extract DigestInfo
+ * @param decrypted The decrypted signature block
+ * @returns The DigestInfo bytes, or null if padding is invalid
+ */
+function extractDigestInfoFromPKCS1(decrypted: Uint8Array): Uint8Array | null {
+  // PKCS#1 v1.5 signature format:
+  // 0x00 0x01 [0xFF padding] 0x00 [DigestInfo]
+  if (decrypted[0] !== 0x00 || decrypted[1] !== 0x01) {
+    return null;
+  }
+
+  // Find the 0x00 separator after padding
+  let separatorIndex = -1;
+  for (let i = 2; i < decrypted.length; i++) {
+    if (decrypted[i] === 0x00) {
+      separatorIndex = i;
+      break;
+    }
+    if (decrypted[i] !== 0xff) {
+      return null; // Invalid padding byte
+    }
+  }
+
+  if (separatorIndex === -1 || separatorIndex < 10) {
+    return null; // No separator found or padding too short
+  }
+
+  return decrypted.slice(separatorIndex + 1);
+}
+
+/**
+ * Extract hash from DigestInfo structure
+ * Handles both standard (with NULL) and non-standard (without NULL) formats
+ */
+function extractHashFromDigestInfo(
+  digestInfo: Uint8Array,
+  expectedHashLength: number,
+): Uint8Array | null {
+  // DigestInfo ::= SEQUENCE { digestAlgorithm AlgorithmIdentifier, digest OCTET STRING }
+  // Look for OCTET STRING tag (0x04) followed by the hash
+  for (let i = 0; i < digestInfo.length - 1; i++) {
+    if (digestInfo[i] === 0x04) {
+      const len = digestInfo[i + 1];
+      if (len === expectedHashLength && i + 2 + len <= digestInfo.length) {
+        return digestInfo.slice(i + 2, i + 2 + len);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Get hash length in bytes for a given algorithm
+ */
+function getHashLength(hashAlgorithm: string): number {
+  const algo = hashAlgorithm.toLowerCase().replace("-", "");
+  switch (algo) {
+    case "sha1":
+      return 20;
+    case "sha256":
+      return 32;
+    case "sha384":
+      return 48;
+    case "sha512":
+      return 64;
+    default:
+      return 32;
+  }
+}
+
+/**
+ * Detects if code is running in a browser environment
+ */
+function isBrowser(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.crypto !== "undefined" &&
+    typeof window.crypto.subtle !== "undefined"
+  );
+}
+
+/**
+ * Verify RSA signature with non-standard DigestInfo format.
+ *
+ * This function performs RSA signature verification that tolerates
+ * non-standard DigestInfo formats (missing NULL in AlgorithmIdentifier).
+ *
+ * - Node.js: Uses native crypto.publicDecrypt() for speed
+ * - Browser: Uses BigInt math (Web Crypto doesn't expose raw RSA)
+ *
+ * @param publicKeyData SPKI-formatted public key
+ * @param signatureBytes Raw signature bytes
+ * @param dataToVerify The data that was signed
+ * @param hashAlgorithm Hash algorithm name (e.g., "SHA-1", "SHA-256")
+ * @returns true if signature is valid, false otherwise
+ */
+export async function verifyRsaWithNonStandardDigestInfo(
+  publicKeyData: ArrayBuffer,
+  signatureBytes: Uint8Array,
+  dataToVerify: Uint8Array,
+  hashAlgorithm: string,
+): Promise<boolean> {
+  try {
+    let digestInfo: Uint8Array | null;
+
+    if (isBrowser()) {
+      // Browser: Use BigInt math (Web Crypto doesn't expose raw RSA decryption)
+      const keyParams = parseRSAPublicKey(publicKeyData);
+      if (!keyParams) {
+        return false;
+      }
+
+      const { n, e } = keyParams;
+      const keyLength = Math.ceil(n.toString(16).length / 2);
+
+      const signatureInt = bytesToBigInt(signatureBytes);
+      const decryptedInt = modPow(signatureInt, e, n);
+      const decrypted = bigIntToBytes(decryptedInt, keyLength);
+
+      digestInfo = extractDigestInfoFromPKCS1(decrypted);
+    } else {
+      // Node.js: Use native crypto.publicDecrypt() for speed
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const nodeCrypto = require("crypto");
+
+      const publicKey = nodeCrypto.createPublicKey({
+        key: Buffer.from(publicKeyData),
+        format: "der",
+        type: "spki",
+      });
+
+      const decrypted = nodeCrypto.publicDecrypt(
+        { key: publicKey, padding: nodeCrypto.constants.RSA_PKCS1_PADDING },
+        Buffer.from(signatureBytes),
+      );
+
+      // Node's publicDecrypt already strips PKCS#1 padding, returns DigestInfo directly
+      digestInfo = new Uint8Array(decrypted);
+    }
+
+    if (!digestInfo) {
+      return false;
+    }
+
+    // Extract hash from DigestInfo (tolerates missing NULL)
+    const hashLength = getHashLength(hashAlgorithm);
+    const extractedHash = extractHashFromDigestInfo(digestInfo, hashLength);
+    if (!extractedHash) {
+      return false;
+    }
+
+    // Compute expected hash
+    let expectedHash: Uint8Array;
+    if (isBrowser()) {
+      // Normalize to Web Crypto format: SHA-1, SHA-256, SHA-384, SHA-512
+      let hashName = hashAlgorithm.toUpperCase().replace(/-/g, "");
+      hashName = hashName.replace(/^SHA(\d)/, "SHA-$1");
+      const hashBuffer = await window.crypto.subtle.digest(hashName, dataToVerify);
+      expectedHash = new Uint8Array(hashBuffer);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const nodeCrypto = require("crypto");
+      const hashName = hashAlgorithm.toLowerCase().replace("-", "");
+      expectedHash = nodeCrypto.createHash(hashName).update(Buffer.from(dataToVerify)).digest();
+    }
+
+    // Compare hashes (constant-time comparison)
+    if (extractedHash.length !== expectedHash.length) {
+      return false;
+    }
+    let diff = 0;
+    for (let i = 0; i < extractedHash.length; i++) {
+      diff |= extractedHash[i] ^ expectedHash[i];
+    }
+
+    return diff === 0;
+  } catch {
+    return false;
+  }
+}

--- a/tests-browser/rsa-digestinfo.spec.ts
+++ b/tests-browser/rsa-digestinfo.spec.ts
@@ -1,0 +1,112 @@
+import { expect } from "@esm-bundle/chai";
+import { verifyRsaWithNonStandardDigestInfo } from "../src/core/rsa-digestinfo-workaround";
+
+/**
+ * Synthetic test vectors for non-standard DigestInfo RSA verification.
+ *
+ * These vectors were generated with a custom script that creates an RSA signature
+ * using non-standard DigestInfo format (missing NULL in AlgorithmIdentifier).
+ *
+ * Standard DigestInfo:     30 21 30 09 06 05 2b0e03021a 05 00 04 14 [hash]
+ * Non-standard DigestInfo: 30 1f 30 07 06 05 2b0e03021a       04 14 [hash]
+ *
+ * This mimics old Java signing tools (pre-Java 8) that produced non-standard signatures.
+ */
+const testVectors = {
+  // RSA 2048-bit public key (SPKI format, base64)
+  publicKeyBase64:
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmFFN33TkjlQGqNXi4x4VTI5mEaWKXrjGle8PtZzWWyGB3t1Yg9/ZBspPtKrtHAOWO564997O0m62YA+2pWZg2FCMohIO6q2HApDZBSN7o3y9YpTl1erpBaPA2ni5GZJOvArcwkSIRMSbDwAVszqkAr0XlvvpuY+QhBU7hycBhyR2Be+xLcysHY3JlR14r/doxgh0isCquTA6EdM5Es08hymKMGWiRUssClY3IwYxr2O4RgMUJu+cFX1U7l+VUXOTn03t20rniP4aQJ+Ns11qiqK72aGYF5XOC4X2EWf1uDH9uubRIQx+dcIgRrW/mS8T9Ile8sak7bsYkLNIw3lHwwIDAQAB",
+  // Signature with non-standard DigestInfo (missing NULL in AlgorithmIdentifier)
+  signatureBase64:
+    "kHXyzYVLPZAp4/zxi3yMhl2e6/vaard926H0nXINtXKG7LwAwfPWzUu6ovv/g6BaH6bzUNJt9heQ1fZi6vCvygRScuf5InTzhQbvMV8jxWktJl0K3XDtO3D0DYM3ArncwxcR6C7rdOWMdD5IRNAyDddCTviQHerkTBUOHFrqaIdNCffHJMGmnn5oqfM/kdcMpogZsa8ySM6WoX8u3gm3wP13B5Ny+iV178G941NrKyf3sYkZPCksA6gAzIK8NWUwbIKG33+/LvHLwBJVSW2SCbkNC+NMqCPVAj5WumoDqtZea5sVqMrcjDzRsCcV286zSh3rAd1mY+7hzcNRJCzP2A==",
+  // Test data that was signed
+  testData: "Test data for RSA signature with non-standard DigestInfo format",
+  // Hash algorithm
+  hashAlgorithm: "SHA-1",
+};
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+describe("RSA DigestInfo Workaround (Browser)", () => {
+  it("should verify signature with non-standard DigestInfo format", async () => {
+    const publicKeyData = base64ToArrayBuffer(testVectors.publicKeyBase64);
+    const signatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+    const dataToVerify = new TextEncoder().encode(testVectors.testData);
+
+    const result = await verifyRsaWithNonStandardDigestInfo(
+      publicKeyData,
+      signatureBytes,
+      dataToVerify,
+      testVectors.hashAlgorithm,
+    );
+
+    expect(result).to.equal(true);
+  });
+
+  it("should fail verification with tampered data", async () => {
+    const publicKeyData = base64ToArrayBuffer(testVectors.publicKeyBase64);
+    const signatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+    const tamperedData = new TextEncoder().encode(testVectors.testData + "tampered");
+
+    const result = await verifyRsaWithNonStandardDigestInfo(
+      publicKeyData,
+      signatureBytes,
+      tamperedData,
+      testVectors.hashAlgorithm,
+    );
+
+    expect(result).to.equal(false);
+  });
+
+  it("should fail verification with wrong signature", async () => {
+    const publicKeyData = base64ToArrayBuffer(testVectors.publicKeyBase64);
+    // Corrupt the signature
+    const signatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+    signatureBytes[0] ^= 0xff;
+    const dataToVerify = new TextEncoder().encode(testVectors.testData);
+
+    const result = await verifyRsaWithNonStandardDigestInfo(
+      publicKeyData,
+      signatureBytes,
+      dataToVerify,
+      testVectors.hashAlgorithm,
+    );
+
+    expect(result).to.equal(false);
+  });
+
+  it("should handle different hash algorithm name formats", async () => {
+    const publicKeyData = base64ToArrayBuffer(testVectors.publicKeyBase64);
+    const signatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+    const dataToVerify = new TextEncoder().encode(testVectors.testData);
+
+    // Test with various formats of "SHA-1"
+    const formats = ["SHA-1", "sha1", "SHA1", "sha-1"];
+
+    for (const format of formats) {
+      const result = await verifyRsaWithNonStandardDigestInfo(
+        publicKeyData,
+        signatureBytes,
+        dataToVerify,
+        format,
+      );
+      expect(result, `Failed with format: ${format}`).to.equal(true);
+    }
+  });
+});

--- a/tests/unit/core/rsa-digestinfo-workaround.test.ts
+++ b/tests/unit/core/rsa-digestinfo-workaround.test.ts
@@ -1,0 +1,118 @@
+import { verifyRsaWithNonStandardDigestInfo } from "../../../src/core/rsa-digestinfo-workaround";
+
+/**
+ * Synthetic test vectors for non-standard DigestInfo RSA verification.
+ *
+ * These vectors were generated with a custom script that creates an RSA signature
+ * using non-standard DigestInfo format (missing NULL in AlgorithmIdentifier).
+ *
+ * Standard DigestInfo:     30 21 30 09 06 05 2b0e03021a 05 00 04 14 [hash]
+ * Non-standard DigestInfo: 30 1f 30 07 06 05 2b0e03021a       04 14 [hash]
+ *
+ * This mimics old Java signing tools (pre-Java 8) that produced non-standard signatures.
+ */
+const testVectors = {
+  // RSA 2048-bit public key (SPKI format, base64)
+  publicKeyBase64:
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmFFN33TkjlQGqNXi4x4VTI5mEaWKXrjGle8PtZzWWyGB3t1Yg9/ZBspPtKrtHAOWO564997O0m62YA+2pWZg2FCMohIO6q2HApDZBSN7o3y9YpTl1erpBaPA2ni5GZJOvArcwkSIRMSbDwAVszqkAr0XlvvpuY+QhBU7hycBhyR2Be+xLcysHY3JlR14r/doxgh0isCquTA6EdM5Es08hymKMGWiRUssClY3IwYxr2O4RgMUJu+cFX1U7l+VUXOTn03t20rniP4aQJ+Ns11qiqK72aGYF5XOC4X2EWf1uDH9uubRIQx+dcIgRrW/mS8T9Ile8sak7bsYkLNIw3lHwwIDAQAB",
+  // Signature with non-standard DigestInfo (missing NULL in AlgorithmIdentifier)
+  signatureBase64:
+    "kHXyzYVLPZAp4/zxi3yMhl2e6/vaard926H0nXINtXKG7LwAwfPWzUu6ovv/g6BaH6bzUNJt9heQ1fZi6vCvygRScuf5InTzhQbvMV8jxWktJl0K3XDtO3D0DYM3ArncwxcR6C7rdOWMdD5IRNAyDddCTviQHerkTBUOHFrqaIdNCffHJMGmnn5oqfM/kdcMpogZsa8ySM6WoX8u3gm3wP13B5Ny+iV178G941NrKyf3sYkZPCksA6gAzIK8NWUwbIKG33+/LvHLwBJVSW2SCbkNC+NMqCPVAj5WumoDqtZea5sVqMrcjDzRsCcV286zSh3rAd1mY+7hzcNRJCzP2A==",
+  // Test data that was signed
+  testData: "Test data for RSA signature with non-standard DigestInfo format",
+  // Hash algorithm
+  hashAlgorithm: "SHA-1",
+};
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = Buffer.from(base64, "base64");
+  return binary.buffer.slice(binary.byteOffset, binary.byteOffset + binary.byteLength);
+}
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(base64, "base64"));
+}
+
+describe("RSA DigestInfo Workaround (Node.js)", () => {
+  it("should verify signature with non-standard DigestInfo format", async () => {
+    const publicKeyData = base64ToArrayBuffer(testVectors.publicKeyBase64);
+    const signatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+    const dataToVerify = Buffer.from(testVectors.testData);
+
+    const result = await verifyRsaWithNonStandardDigestInfo(
+      publicKeyData,
+      signatureBytes,
+      dataToVerify,
+      testVectors.hashAlgorithm,
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("should fail verification with tampered data", async () => {
+    const publicKeyData = base64ToArrayBuffer(testVectors.publicKeyBase64);
+    const signatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+    const tamperedData = Buffer.from(testVectors.testData + "tampered");
+
+    const result = await verifyRsaWithNonStandardDigestInfo(
+      publicKeyData,
+      signatureBytes,
+      tamperedData,
+      testVectors.hashAlgorithm,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("should fail verification with wrong signature", async () => {
+    const publicKeyData = base64ToArrayBuffer(testVectors.publicKeyBase64);
+    const signatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+    signatureBytes[0] ^= 0xff; // Corrupt the signature
+    const dataToVerify = Buffer.from(testVectors.testData);
+
+    const result = await verifyRsaWithNonStandardDigestInfo(
+      publicKeyData,
+      signatureBytes,
+      dataToVerify,
+      testVectors.hashAlgorithm,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("should handle different hash algorithm name formats", async () => {
+    const publicKeyData = base64ToArrayBuffer(testVectors.publicKeyBase64);
+    const signatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+    const dataToVerify = Buffer.from(testVectors.testData);
+
+    // Test with various formats of "SHA-1"
+    const formats = ["SHA-1", "sha1", "SHA1", "sha-1"];
+
+    for (const format of formats) {
+      // Need fresh signature bytes since we don't mutate
+      const freshSignatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+      const result = await verifyRsaWithNonStandardDigestInfo(
+        publicKeyData,
+        freshSignatureBytes,
+        dataToVerify,
+        format,
+      );
+      expect(result).toBe(true);
+    }
+  });
+
+  it("should fail with invalid public key", async () => {
+    const invalidKeyData = new ArrayBuffer(10); // Invalid key
+    const signatureBytes = base64ToUint8Array(testVectors.signatureBase64);
+    const dataToVerify = Buffer.from(testVectors.testData);
+
+    const result = await verifyRsaWithNonStandardDigestInfo(
+      invalidKeyData,
+      signatureBytes,
+      dataToVerify,
+      testVectors.hashAlgorithm,
+    );
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION

- Return INDETERMINATE status when timestamp/certificate has expired (instead of INVALID)
- Fix RSA signature verification for non-standard DigestInfo (missing NULL in AlgorithmIdentifier) - affects old pre-Java 8 signed documents
- Fix browser tests to handle new filelist.json format with expectedStatus
