### PR TITLE
Externalize xmldom/xpath for ESM/CJS builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edockit",
-  "version": "0.3.0",
+  "version": "0.4.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edockit",
-      "version": "0.3.0",
+      "version": "0.4.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-ocsp": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edockit",
-  "version": "0.3.0",
+  "version": "0.4.0-dev.0",
   "main": "dist/index.cjs.js",
   "scripts": {
     "test": "jest --silent",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,18 @@ function createTypescriptPlugin() {
 }
 
 function isExternalModule(id) {
+  return (
+    id === "fflate" ||
+    id === "@peculiar/x509" ||
+    id === "@xmldom/xmldom" ||
+    id === "xpath" ||
+    id === "crypto" ||
+    id.startsWith("node:") ||
+    id.startsWith("@peculiar/asn1-")
+  );
+}
+
+function isExternalModuleUmd(id) {
   return id === "fflate" || id === "@peculiar/x509" || id === "crypto" || id.startsWith("node:");
 }
 
@@ -73,7 +85,7 @@ const rootUmdBuild = {
       target: "es2015",
     }),
   ],
-  external: isExternalModule,
+  external: isExternalModuleUmd,
 };
 
 export default [moduleBuild, rootUmdBuild];

--- a/scripts/build-dist.mjs
+++ b/scripts/build-dist.mjs
@@ -19,6 +19,18 @@ function createTypescriptPlugin() {
 }
 
 function isExternalModule(id) {
+  return (
+    id === "fflate" ||
+    id === "@peculiar/x509" ||
+    id === "@xmldom/xmldom" ||
+    id === "xpath" ||
+    id === "crypto" ||
+    id.startsWith("node:") ||
+    id.startsWith("@peculiar/asn1-")
+  );
+}
+
+function isExternalModuleUmd(id) {
   return id === "fflate" || id === "@peculiar/x509" || id === "crypto" || id.startsWith("node:");
 }
 
@@ -64,7 +76,7 @@ function createRootUmdBuildConfig() {
         target: "es2015",
       }),
     ],
-    external: isExternalModule,
+    external: isExternalModuleUmd,
     output: {
       file: packageJson.browser,
       format: "umd",

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -322,8 +322,8 @@ export function querySelector(parent: Document | Element, selector: string): Ele
 
   // Then try XPath as a fallback
   try {
-    const xpath = selectorToXPath(selector);
-    return queryByXPath(parent, xpath);
+    const xpathExpr = selectorToXPath(selector);
+    return queryByXPath(parent, xpathExpr);
   } catch (e) {
     console.warn("XPath query failed, using direct DOM traversal as fallback");
     return null;
@@ -363,8 +363,8 @@ export function querySelectorAll(parent: Document | Element, selector: string): 
 
   // Then try XPath as a fallback
   try {
-    const xpath = selectorToXPath(selector);
-    return queryAllByXPath(parent, xpath);
+    const xpathExpr = selectorToXPath(selector);
+    return queryAllByXPath(parent, xpathExpr);
   } catch (e) {
     console.warn("XPath query failed, using direct DOM traversal as fallback");
     return [];

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -1,3 +1,6 @@
+import * as xmldom from "@xmldom/xmldom";
+import * as xpath from "xpath";
+
 /**
  * Recursive DOM traversal to find elements with a given tag name
  * (Fallback method when XPath is not available or fails)
@@ -99,15 +102,7 @@ export function createXMLParser(): XMLParserInterface {
   }
 
   // We're in Node.js, so use xmldom
-  try {
-    // Import dynamically to avoid bundling issues
-    const { DOMParser } = require("@xmldom/xmldom");
-    return new DOMParser();
-  } catch (e) {
-    throw new Error(
-      "XML DOM parser not available. In Node.js environments, please install @xmldom/xmldom package.",
-    );
-  }
+  return new xmldom.DOMParser() as unknown as XMLParserInterface;
 }
 
 /**
@@ -145,12 +140,12 @@ export function queryByXPath(
     }
     // Node.js environment with xpath module
     else {
-      const xpath = require("xpath");
+      const xpathLib = xpath;
       const nsResolver = createNsResolverForNode(namespaces);
 
       // Use a try-catch here to handle specific XPath issues
       try {
-        const nodes = xpath.select(xpathExpression, parent, nsResolver);
+        const nodes = xpathLib.select(xpathExpression, parent as any, nsResolver) as any;
         return nodes.length > 0 ? nodes[0] : null;
       } catch (err: unknown) {
         // If we get a namespace error, try a simpler XPath with just local-name()
@@ -166,7 +161,7 @@ export function queryByXPath(
           if (match && match[1]) {
             const elementName = match[1];
             const simplifiedXPath = `.//*[local-name()='${elementName}']`;
-            const nodes = xpath.select(simplifiedXPath, parent);
+            const nodes = xpathLib.select(simplifiedXPath, parent as any) as any;
             return nodes.length > 0 ? nodes[0] : null;
           }
         }
@@ -219,12 +214,12 @@ export function queryAllByXPath(
     }
     // Node.js environment with xpath module
     else {
-      const xpath = require("xpath");
+      const xpathLib = xpath;
       const nsResolver = createNsResolverForNode(namespaces);
 
       // Use a try-catch here to handle specific XPath issues
       try {
-        const nodes = xpath.select(xpathExpression, parent, nsResolver);
+        const nodes = xpathLib.select(xpathExpression, parent as any, nsResolver) as any;
         return nodes as Element[];
       } catch (err: unknown) {
         // If we get a namespace error, try a simpler XPath with just local-name()
@@ -240,7 +235,7 @@ export function queryAllByXPath(
           if (match && match[1]) {
             const elementName = match[1];
             const simplifiedXPath = `.//*[local-name()='${elementName}']`;
-            const nodes = xpath.select(simplifiedXPath, parent);
+            const nodes = xpathLib.select(simplifiedXPath, parent as any) as any;
             return nodes as Element[];
           }
         }
@@ -385,15 +380,8 @@ export function serializeToXML(node: Node): string {
     return new window.XMLSerializer().serializeToString(node);
   }
 
-  // If we're using xmldom
-  try {
-    const { XMLSerializer } = require("@xmldom/xmldom");
-    return new XMLSerializer().serializeToString(node);
-  } catch (e) {
-    throw new Error(
-      "XML Serializer not available. In Node.js environments, please install @xmldom/xmldom package.",
-    );
-  }
+  // Node.js — use xmldom
+  return new xmldom.XMLSerializer().serializeToString(node as any);
 }
 
 /**

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -34,6 +34,23 @@ const config = {
   browsers,
 
   plugins: [
+    // Stub out Node-only deps before esbuild tries to resolve them
+    {
+      name: "stub-node-deps",
+      resolveImport({ source }) {
+        if (source === "@xmldom/xmldom" || source === "xpath") {
+          return `/__node-stub__/${source}`;
+        }
+      },
+      serve(context) {
+        if (context.path.startsWith("/__node-stub__/")) {
+          return {
+            body: "export default {}; export const DOMParser = undefined; export const XMLSerializer = undefined; export const select = undefined;",
+            type: "js",
+          };
+        }
+      },
+    },
     esbuildPlugin({
       ts: true,
       tsconfig: "./tsconfig.json",


### PR DESCRIPTION
## Summary
- Replace inline `require()` with top-level `import` for `@xmldom/xmldom` and `xpath` in xmlParser.ts
- Mark both as external in Rollup ESM/CJS build config, so output uses proper `import`/`require` statements
- Keep them bundled inline for UMD (browser) build via separate `isExternalModuleUmd` function
- Stub out these Node-only deps in web-test-runner so browser tests don't try to load them
- Also externalizes `@peculiar/asn1-*` packages (were being unnecessarily bundled)

Fixes `"XML DOM parser not available"` error when ESM consumers (projects with `"type": "module"`) use `edockit/trusted-list/build` in Node.js.

## Test plan
- [x] All 122 unit/integration tests pass
- [x] All 37 browser tests pass
- [x] ESM output verified to use `import` statements for xmldom/xpath